### PR TITLE
Replace Moose::Role everywhere with Role::Tiny

### DIFF
--- a/lib/Moose/Autobox.pm
+++ b/lib/Moose/Autobox.pm
@@ -6,7 +6,7 @@ use warnings;
 
 use Carp ();
 use Scalar::Util ();
-use Moose::Util  ();
+use Moo::Role  2.000 ();
 
 our $VERSION = '0.16';
 
@@ -25,7 +25,7 @@ sub mixin_additional_role {
     my ($class, $type, $role) = @_;
     ($type =~ /SCALAR|ARRAY|HASH|CODE/)
         || Carp::confess "Can only add additional roles to SCALAR, ARRAY, HASH or CODE";
-    Moose::Util::apply_all_roles(('Moose::Autobox::' . $type)->meta, ($role));
+    Moo::Role->apply_roles_to_package('Moose::Autobox::' . $type, $role);
 }
 
 {
@@ -34,44 +34,28 @@ sub mixin_additional_role {
 
     use Moose::Autobox::Scalar;
 
-    use metaclass 'Moose::Meta::Class';
-
-    Moose::Util::apply_all_roles(__PACKAGE__->meta, ('Moose::Autobox::Scalar'));
-
-    *does = \&Moose::Object::does;
+    Moo::Role->apply_roles_to_package(__PACKAGE__,'Moose::Autobox::Scalar');
 
     package
       Moose::Autobox::ARRAY;
 
     use Moose::Autobox::Array;
 
-    use metaclass 'Moose::Meta::Class';
-
-    Moose::Util::apply_all_roles(__PACKAGE__->meta, ('Moose::Autobox::Array'));
-
-    *does = \&Moose::Object::does;
+    Moo::Role->apply_roles_to_package(__PACKAGE__,'Moose::Autobox::Array');
 
     package
       Moose::Autobox::HASH;
 
     use Moose::Autobox::Hash;
 
-    use metaclass 'Moose::Meta::Class';
-
-    Moose::Util::apply_all_roles(__PACKAGE__->meta, ('Moose::Autobox::Hash'));
-
-    *does = \&Moose::Object::does;
+    Moo::Role->apply_roles_to_package(__PACKAGE__,'Moose::Autobox::Hash');
 
     package
       Moose::Autobox::CODE;
 
     use Moose::Autobox::Code;
 
-    use metaclass 'Moose::Meta::Class';
-
-    Moose::Util::apply_all_roles(__PACKAGE__->meta, ('Moose::Autobox::Code'));
-
-    *does = \&Moose::Object::does;
+    Moo::Role->apply_roles_to_package(__PACKAGE__,'Moose::Autobox::Code');
 }
 
 1;

--- a/lib/Moose/Autobox/Array.pm
+++ b/lib/Moose/Autobox/Array.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Array;
 # ABSTRACT: the Array role
-use Moose::Role 'with';
+use Moo::Role 2.000 'with';
 use Moose::Autobox;
 
 use Syntax::Keyword::Junction::All ();
@@ -150,6 +150,7 @@ sub each_value {
 
 sub each_n_values {
     my ($array, $n, $sub) = @_;
+    require List::MoreUtils;
     my $it = List::MoreUtils::natatime($n, @$array);
 
     while (my @vals = $it->()) {
@@ -209,8 +210,6 @@ sub one {
 
 sub print { CORE::print @{$_[0]} }
 sub say   { CORE::print @{$_[0]}, "\n" }
-
-no Moose::Role;
 
 1;
 __END__

--- a/lib/Moose/Autobox/Code.pm
+++ b/lib/Moose/Autobox/Code.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Code;
 # ABSTRACT: the Code role
-use Moose::Role 'with';
+use Moo::Role 'with';
 use Moose::Autobox;
 use namespace::autoclean;
 

--- a/lib/Moose/Autobox/Defined.pm
+++ b/lib/Moose/Autobox/Defined.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Defined;
 # ABSTRACT: the Defined role
-use Moose::Role 'with';
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/Hash.pm
+++ b/lib/Moose/Autobox/Hash.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Hash;
 # ABSTRACT: the Hash role
-use Moose::Role 'with';
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/Indexed.pm
+++ b/lib/Moose/Autobox/Indexed.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Indexed;
 # ABSTRACT: the Indexed role
-use Moose::Role 'requires';
+use Moo::Role 'requires';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/Item.pm
+++ b/lib/Moose/Autobox/Item.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Item;
 # ABSTRACT: the Item role
-use Moose::Role 'requires';
+use Moo::Role 'requires';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/List.pm
+++ b/lib/Moose/Autobox/List.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::List;
 # ABSTRACT: the List role
-use Moose::Role 'with', 'requires';
+use Role::Tiny 'with', 'requires';
 use Moose::Autobox;
 use namespace::autoclean;
 

--- a/lib/Moose/Autobox/Number.pm
+++ b/lib/Moose/Autobox/Number.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Number;
 # ABSTRACT: Moose::Autobox::Number - the Number role
-use Moose::Role;
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/Ref.pm
+++ b/lib/Moose/Autobox/Ref.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Ref;
 # ABSTRACT: the Ref role
-use Moose::Role 'with';
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/Scalar.pm
+++ b/lib/Moose/Autobox/Scalar.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Scalar;
 # ABSTRACT: the Scalar role
-use Moose::Role 'with';
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/String.pm
+++ b/lib/Moose/Autobox/String.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::String;
 # ABSTRACT: the String role
-use Moose::Role;
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/Undef.pm
+++ b/lib/Moose/Autobox/Undef.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Undef;
 # ABSTRACT: the Undef role
-use Moose::Role 'with';
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/lib/Moose/Autobox/Value.pm
+++ b/lib/Moose/Autobox/Value.pm
@@ -1,6 +1,6 @@
 package Moose::Autobox::Value;
 # ABSTRACT: Moose::Autobox::Value - the Value role
-use Moose::Role 'with';
+use Moo::Role 'with';
 use namespace::autoclean;
 
 our $VERSION = '0.16';

--- a/t/003_p6_example.t
+++ b/t/003_p6_example.t
@@ -14,7 +14,7 @@ This comes from one of the examples in the Pugs distro.
 
 {
     package Units::Bytes;
-    use Moose::Role;
+    use Role::Tiny;
     use Moose::Autobox;
 
     sub bytes     { $_[0]                   }


### PR DESCRIPTION
I've done a minimum first pass just for interests sake. However, the limitations I've hit are as follows:
### SERIOUS : using Role::Tiny's method composition may in effect break every existing extension

That is, everyone who actually uses `sub mixin_additional_role {` and a Moose based Role will have their code broken by the fact `Role::Tiny` presently fails when this is called on a non-Role::Tiny role.

``` perl
    Role::Tiny->apply_roles_to_package('Moose::Autobox::' . $type, $role);
```

[1](https://github.com/moose/Moose-Autobox/pull/1/files#diff-d198f1704cd54bcc01898628b9eecc98R28)

Which is unacceptable and needs a workaround. This was exposed by the tests failing which I didn't initially convert `Moose::Role` based tests.

There is only one such known victim: http://grep.cpan.me/?q=mixin_additional_role 
### Needs discussion: Handling of `>5.21.2`'s `redundant` warning.

`Moose::Autobox` presently warns on blead about  `Redundant argument in sprintf at /home/kent/perl/forks/Moose-Autobox/lib/Moose/Autobox/Array.pm line 53`

And because warnings are lexical, there is no way for a user to suppress that warning, even though the warning is intended for consumers of Moose::Autobox, not really intended for Moose::Autobox itself.

And because `Role::Tiny` applies `use warnings FATAL => q[all]`, this adjustment causes sprintf to fatalize , and was also exposed as such by a test.

The easy obvious work-around is to simply suppress that warning lexically, which I have done, but it feels icky as the warning aught to be propagated, but the user's warnings should indicate how it propagates, not Moose::Autobox'es.

We could simply ignore that fact of course, but then we're effectively hiding a potential bug the user has committed that perl itself would have warned them about, which I consider to be a regression.
[2](https://github.com/moose/Moose-Autobox/pull/1/files#diff-ef05b873577bc9700d4e19de068cf436R53)
