### PR TITLE
Add explicit List::MoreUtils dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -21,3 +21,4 @@ conflicts_module = Moose::Conflicts
 [Prereqs / RuntimeRequires]
 autobox = 2.23
 Moose = 0.42
+List::MoreUtils = 0.07

--- a/lib/Moose/Autobox/Array.pm
+++ b/lib/Moose/Autobox/Array.pm
@@ -2,6 +2,7 @@ package Moose::Autobox::Array;
 # ABSTRACT: the Array role
 use Moose::Role 'with';
 use Moose::Autobox;
+use List::MoreUtils ();
 
 use Syntax::Keyword::Junction::All ();
 use Syntax::Keyword::Junction::Any ();


### PR DESCRIPTION
Hello!

Moose::Autobox wouldn't install on my system. I dug into it a little, and it turns out that Moose::Autobox::Array uses List::MoreUtils, but wasn't actually loading the module. So I've added the missing "use" statement, and set the minimum version of List::MoreUtils to 0.07 (ancient, but
that's when natatime was introduced).

Cheers!